### PR TITLE
feat: add Abstract chain support (Chain ID 2741)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,7 @@ BASE_RPC_URL=https://base-mainnet.g.alchemy.com/v2/YOUR_KEY
 # HYPEREVM_RPC_URL=https://rpc.hyperliquid.xyz/evm
 # INK_RPC_URL=https://rpc-gel.inkonchain.com
 # MONAD_RPC_URL=https://rpc.monad.xyz
+# ABSTRACT_RPC_URL=https://api.mainnet.abs.xyz
 
 # Solana (optional — also requires SOLANA_FACILITATOR_PRIVATE_KEY)
 # SOLANA_RPC_URL=https://api.mainnet-beta.solana.com

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -17,9 +17,10 @@
 //        Uses TransferChecked with partial signing
 //        Requires SOLANA_FACILITATOR_PRIVATE_KEY for gas
 //
-// IMPORTANT: Only native USDC is supported, NOT bridged USDC.e
-//   Bridged tokens use different contract implementations
-//   that may not support EIP-3009.
+// IMPORTANT: Only Circle-issued USDC with EIP-3009 support is compatible.
+//   Abstract uses USDC.e (Bridged USDC via Stargate), which is a Circle
+//   FiatTokenProxy (FiatTokenV2) with full EIP-3009 support — verified on-chain.
+//   Standard bridged USDC.e from other bridges may NOT support EIP-3009.
 //
 // To add a new EVM chain:
 //   1. Add network config below with CAIP-2 ID and RPC env var
@@ -182,6 +183,24 @@ const MONAD = {
   token: usdcv2('0x754704Bc059F8C67012fEd69BC8a327a5aafb603')
 };
 
+// Abstract (ZK rollup, EVM-compatible)
+// Uses USDC.e (Bridged USDC via Stargate) — a Circle FiatTokenProxy (FiatTokenV2)
+// with full EIP-3009 (transferWithAuthorization) support, verified on-chain.
+// EIP-712 domain: name="Bridged USDC (Stargate)", version="2", decimals=6
+// Contract: https://abscan.org/address/0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1
+const ABSTRACT = {
+  vm: 'evm',
+  caip2: 'eip155:2741',
+  chainId: 2741,
+  rpcEnvVar: 'ABSTRACT_RPC_URL',
+  token: {
+    address: '0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1',
+    name: 'Bridged USDC (Stargate)',
+    version: '2',
+    decimals: 6,
+  },
+};
+
 // ─── Facilitator-based Networks ────────────────────────────
 // For chains where the stablecoin doesn't natively support EIP-3009,
 // use an external facilitator service to verify + settle payments.
@@ -248,6 +267,7 @@ const ALL_NETWORKS = {
   'eip155:999': HYPEREVM,
   'eip155:57073': INK,
   'eip155:143': MONAD,
+  'eip155:2741': ABSTRACT,
   'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': SOLANA_MAINNET,
 };
 

--- a/src/middleware/x402.js
+++ b/src/middleware/x402.js
@@ -22,7 +22,8 @@ import {
   sonic,
   hyperEvm,
   ink,
-  monad
+  monad,
+  abstract,
 } from 'viem/chains';
 import { ROUTE_CONFIG, SUPPORTED_NETWORKS, CREDIT_DEFAULTS } from '../config/routes.js';
 import {
@@ -83,6 +84,7 @@ const VIEM_CHAINS = {
   999: hyperEvm,
   57073: ink,
   143: monad,
+  2741: abstract,
   // Add more: import from viem/chains and register here
 };
 


### PR DESCRIPTION
## Summary

Adds support for [Abstract](https://abs.xyz) (EVM-compatible ZK rollup, Chain ID 2741) to the x402 gateway template.

## Changes

- **`src/config/routes.js`** — adds `ABSTRACT` network config with USDC.e token details; registers in `ALL_NETWORKS`; updates EIP-3009 comment to clarify that Abstract's USDC.e qualifies
- **`src/middleware/x402.js`** — imports `abstract` chain from `viem/chains`; registers Chain ID 2741 in `VIEM_CHAINS`
- **`.env.example`** — adds `ABSTRACT_RPC_URL` (commented out)

## Token Details

Abstract uses **USDC.e (Bridged USDC via Stargate)** — a Circle FiatTokenProxy (FiatTokenV2) with full EIP-3009 (`transferWithAuthorization`) support, verified on-chain:

| Field | Value |
|---|---|
| Contract | `0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1` |
| EIP-712 name | `Bridged USDC (Stargate)` |
| EIP-712 version | `2` |
| Decimals | 6 |
| Abscan | [View contract](https://abscan.org/address/0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1) |

Unlike generic bridged USDC, this token uses Circle's own FiatTokenProxy implementation — the same contract family as native USDC on Base, Ethereum, etc. EIP-3009 support is confirmed.

## Network Details

| Field | Value |
|---|---|
| Chain ID | 2741 |
| CAIP-2 | `eip155:2741` |
| Public RPC | `https://api.mainnet.abs.xyz` |
| Explorer | [abscan.org](https://abscan.org) |

Abstract chain support is also already present in `@x402/evm` (the core package) — this PR adds the gateway template config to match.

## Testing

To enable Abstract in your gateway, add to `.env`:
```
ABSTRACT_RPC_URL=https://api.mainnet.abs.xyz
```

The settlement wallet needs Abstract ETH for gas (very low — Abstract is a ZK rollup).